### PR TITLE
Add apt-sudo microagent for apt-get commands

### DIFF
--- a/.openhands/microagents/apt_sudo.md
+++ b/.openhands/microagents/apt_sudo.md
@@ -1,0 +1,16 @@
+---
+name: apt-sudo
+type: knowledge
+version: 1.0.0
+agent: CodeActAgent
+triggers: []
+---
+
+# Apt Sudo Microagent
+
+This microagent ensures that any usage of `apt-get` for installing packages is prefixed with `sudo`. It can be used in scripts or commands where elevated privileges are required.
+
+**Usage Example:**
+```
+sudo apt-get update && sudo apt-get install -y <package>
+```


### PR DESCRIPTION
This PR adds a new microagent in `.openhands/microagents/apt_sudo.md` that ensures any `apt-get` installation is prefixed with `sudo`. No triggers are defined.

The microagent follows the standard format with metadata and usage example.