### PR TITLE
Increase test coverage: add frame and config tests

### DIFF
--- a/echonetlite/frame_test.go
+++ b/echonetlite/frame_test.go
@@ -1,0 +1,45 @@
+package echonetlite
+
+import (
+    "bytes"
+    "reflect"
+    "testing"
+)
+
+func TestMarshalUnmarshalBinary(t *testing.T) {
+    // Construct a sample frame with one property
+    original := Frame{
+        EHD1: EchonetLiteEHD1,
+        EHD2: Format1,
+        TID:  0x1234,
+        SEOJ: NewEOJ(0x05, 0xFF, 0x01),
+        DEOJ: NewEOJ(0x02, 0x7D, 0x01),
+        ESV:  ESVGet,
+        OPC:  1,
+        Properties: []Property{{EPC: 0xE4, PDC: 0x00, EDT: nil}},
+    }
+
+    data, err := original.MarshalBinary()
+    if err != nil {
+        t.Fatalf("MarshalBinary failed: %v", err)
+    }
+
+    var decoded Frame
+    if err := decoded.UnmarshalBinary(data); err != nil {
+        t.Fatalf("UnmarshalBinary failed: %v", err)
+    }
+
+    // Compare fields (except OPC which may be set by caller). Ensure equality.
+    if !reflect.DeepEqual(original, decoded) {
+        t.Errorf("Round‑trip mismatch.\nOriginal: %+v\nDecoded : %+v", original, decoded)
+    }
+
+    // Additional sanity: ensure MarshalBinary of decoded yields same bytes
+    data2, err := decoded.MarshalBinary()
+    if err != nil {
+        t.Fatalf("MarshalBinary on decoded failed: %v", err)
+    }
+    if !bytes.Equal(data, data2) {
+        t.Errorf("Serialized bytes differ after round‑trip")
+    }
+}

--- a/main.go
+++ b/main.go
@@ -310,11 +310,9 @@ func getPropertyName(deoj echonetlite.EOJ, epc byte) string {
 }
 
 // isChargingTime は、現在時刻が設定された充電時間帯内にあるかどうかを判定します。
-func isChargingTime(startTimeStr, endTimeStr string) (bool, error) {
+func isChargingTime(startTimeStr, endTimeStr string, now time.Time) (bool, error) {
 	const timeFormat = "15:04"
-	now := time.Now()
-
-	// 時刻部分のみを抽出
+       // Use provided current time
 	currentTime, err := time.Parse(timeFormat, now.Format(timeFormat))
 	if err != nil {
 		return false, fmt.Errorf("現在時刻の解析に失敗しました: %w", err)
@@ -423,7 +421,7 @@ func main() {
 		log.Println("--------------------------------------------------")
 		log.Println("監視サイクル開始")
 
-		isChargingTimePeriod, err := isChargingTime(cfg.ChargeStartTime, cfg.ChargeEndTime)
+               isChargingTimePeriod, err := isChargingTime(cfg.ChargeStartTime, cfg.ChargeEndTime, time.Now())
 		if err != nil {
 			log.Printf("充電時間帯の判定に失敗しました: %v", err)
 		} else {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+    "os"
+    "testing"
+)
+
+func TestLoadConfigDefaults(t *testing.T) {
+    // create temporary config with only required field
+    tmp, err := os.CreateTemp("", "config_*.toml")
+    if err != nil { t.Fatalf("temp file: %v", err) }
+    defer os.Remove(tmp.Name())
+    _, err = tmp.WriteString("target_ip = \"192.168.0.10\"\n")
+    if err != nil { t.Fatalf("write: %v", err) }
+    tmp.Close()
+
+    cfg, err := loadConfig(tmp.Name())
+    if err != nil { t.Fatalf("loadConfig error: %v", err) }
+    if cfg.TargetIP != "192.168.0.10" {
+        t.Errorf("TargetIP mismatch: got %s", cfg.TargetIP)
+    }
+    // defaults
+    if cfg.MonitorIntervalSeconds != 10 { t.Errorf("default MonitorIntervalSeconds not set") }
+    if cfg.ChargePowerUpdateIntervalMinutes != 10 { t.Errorf("default ChargePowerUpdateIntervalMinutes not set") }
+    if cfg.ModeChangeInhibitMinutes != 5 { t.Errorf("default ModeChangeInhibitMinutes not set") }
+    if cfg.MinSurplusPowerJudgmentMinutes != 5 { t.Errorf("default MinSurplusPowerJudgmentMinutes not set") }
+    if cfg.SurplusPowerMarginWatts != 500 { t.Errorf("default SurplusPowerMarginWatts not set") }
+    if cfg.MaxChargePowerWatts != 3000 { t.Errorf("default MaxChargePowerWatts not set") }
+}
+
+func TestIsChargingTime(t *testing.T) {
+    // simple within same day
+    ok, err := isChargingTime("09:00", "17:00")
+    if err != nil { t.Fatalf("error: %v", err) }
+    // depends on current time; just ensure no error and bool returned
+    _ = ok
+
+    // crossing midnight
+    ok2, err := isChargingTime("23:00", "02:00")
+    if err != nil { t.Fatalf("error crossing: %v", err) }
+    _ = ok2
+}

--- a/main_test.go
+++ b/main_test.go
@@ -30,14 +30,38 @@ func TestLoadConfigDefaults(t *testing.T) {
 }
 
 func TestIsChargingTime(t *testing.T) {
-    // simple within same day
-    ok, err := isChargingTime("09:00", "17:00", time.Now())
+    // simple within same day - expect true between 09:00 and 17:00 at 12:00
+    fixedNow := time.Date(2025, time.September, 15, 12, 0, 0, 0, time.UTC)
+    ok, err := isChargingTime("09:00", "17:00", fixedNow)
     if err != nil { t.Fatalf("error: %v", err) }
-    // depends on current time; just ensure no error and bool returned
-    _ = ok
+    if !ok {
+        t.Errorf("expected charging time within range to be true")
+    }
 
-    // crossing midnight
-    ok2, err := isChargingTime("23:00", "02:00", time.Now())
+    // crossing midnight - expect true at 01:30 between 23:00 and 02:00
+    fixedNow2 := time.Date(2025, time.September, 15, 1, 30, 0, 0, time.UTC)
+    ok2, err := isChargingTime("23:00", "02:00", fixedNow2)
     if err != nil { t.Fatalf("error crossing: %v", err) }
-    _ = ok2
+    if !ok2 {
+        t.Errorf("expected charging time across midnight to be true")
+    }
 }
+
+func TestIsChargingTimeFalse(t *testing.T) {
+    // time outside range should return false
+    fixedNow := time.Date(2025, time.September, 15, 8, 0, 0, 0, time.UTC)
+    ok, err := isChargingTime("09:00", "17:00", fixedNow)
+    if err != nil { t.Fatalf("error: %v", err) }
+    if ok {
+        t.Errorf("expected charging time outside range to be false")
+    }
+
+    // crossing midnight false case
+    fixedNow2 := time.Date(2025, time.September, 15, 3, 0, 0, 0, time.UTC)
+    ok2, err := isChargingTime("23:00", "02:00", fixedNow2)
+    if err != nil { t.Fatalf("error crossing false: %v", err) }
+    if ok2 {
+        t.Errorf("expected charging time outside midnight range to be false")
+    }
+}
+

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
     "os"
     "testing"
+    "time"
 )
 
 func TestLoadConfigDefaults(t *testing.T) {
@@ -30,13 +31,13 @@ func TestLoadConfigDefaults(t *testing.T) {
 
 func TestIsChargingTime(t *testing.T) {
     // simple within same day
-    ok, err := isChargingTime("09:00", "17:00")
+    ok, err := isChargingTime("09:00", "17:00", time.Now())
     if err != nil { t.Fatalf("error: %v", err) }
     // depends on current time; just ensure no error and bool returned
     _ = ok
 
     // crossing midnight
-    ok2, err := isChargingTime("23:00", "02:00")
+    ok2, err := isChargingTime("23:00", "02:00", time.Now())
     if err != nil { t.Fatalf("error crossing: %v", err) }
     _ = ok2
 }


### PR DESCRIPTION
This PR adds unit tests to improve coverage:

- `echonetlite/frame_test.go` verifies MarshalBinary/UnmarshalBinary round‑trip.
- `main_test.go` checks default values from `loadConfig` and basic behavior of `isChargingTime`.

All tests pass (`go test ./...`).